### PR TITLE
Display image creation dates on the "tags" page

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -85,6 +85,9 @@ grails.project.dependency.resolution = {
     //compile ":coffee-asset-pipeline:1.8.0"
     //compile ":handlebars-asset-pipeline:1.3.0.3"
     compile ":twitter-bootstrap:3.3.4"
+
+    // for formatting relative timestamps
+    compile ":pretty-time:2.1.3.Final-1.0.1"
   }
 }
 

--- a/grails-app/controllers/docker/registry/web/RepositoryController.groovy
+++ b/grails-app/controllers/docker/registry/web/RepositoryController.groovy
@@ -40,7 +40,16 @@ class RepositoryController {
           restService.headLength("${name}/blobs/${digest}") ?: 0
         }
       }
-      [name: tag, data: manifest.json, size: size, exists: exists, id: topLayer?.id?.substring(0, 11)]
+
+      // docker uses ISO8601 dates w/ fractional seconds (i.e. yyyy-MM-ddTHH:mm:ss.ssssssssZ),
+      // which seem to confuse the Date parser, so truncate the timestamp and always assume UTC tz.
+      def createdStr = topLayer?.created?.substring(0,19)
+      def createdDate
+      if (createdStr) {
+        createdDate = Date.parse("yyyy-MM-dd'T'HH:mm:ss", createdStr)
+      }
+
+      [name: tag, data: manifest.json, size: size, exists: exists, id: topLayer?.id?.substring(0, 11), created: createdDate, createdStr: createdStr]
     }
     tags
   }

--- a/grails-app/views/repository/tags.gsp
+++ b/grails-app/views/repository/tags.gsp
@@ -23,7 +23,7 @@
 
         <div class="table-responsive">
             <table class="table table-bordered table-hover">
-                <tr><th>Id</th><th>Tag</th><th>Layers</th><th>Size</th>
+                <tr><th>Id</th><th>Tag</th><th>Created</th><th>Layers</th><th>Size</th>
                     <g:if test="${!grailsApplication.config.registry.readonly}">
                         <th>Delete</th>
                     </g:if>
@@ -33,6 +33,7 @@
                         <tr><td>${tag.id}</td>
                             <td><g:link action="tag" params="[name: tag.name]"
                                         id="${params.id}">${tag.name}</g:link></td>
+                            <td><prettytime:display date="${tag.created}" /><br /><small>${tag.createdStr}</small></td>
                             <td>${tag.data.fsLayers.size()}</td><td><g:formatSize value="${tag.size}"/></td>
                             <g:if test="${!grailsApplication.config.registry.readonly}">
                             <td><g:link action="delete" params="[name: params.id]" id="${tag.name}">Delete</g:link></td>


### PR DESCRIPTION
This patch adds a column to the "Tags" page that displays the image creation date, similar to that shown by the `docker images` command. It shows both a relative date and ISO datetime of the latest layer in the manifest history.

Possibly addresses #2, although the issue description is vague.

P.S. I haven't worked with Groovy/rails before so apologies for anything un-idiomatic.
 
<img width="1225" alt="screen shot 2015-09-26 at 8 22 27 pm" src="https://cloud.githubusercontent.com/assets/605806/10120999/96c9e1cc-648c-11e5-8078-daff51aaea73.png">