### PR TITLE
Fixing use of REGISTRY_CONTEXT_PATH env var

### DIFF
--- a/tomcat/start.sh
+++ b/tomcat/start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-CONTEXT_PATH=`yml.pl /conf/config.yml registry.context_path`
-CATALINA_OPTS="$CATALINA_OPTS -Dcontext.path=${CONTEXT_PATH}"
+CONTEXT_PATH=$(yml.pl /conf/config.yml registry.context_path)
+CATALINA_OPTS="$CATALINA_OPTS -Dcontext.path=${REGISTRY_CONTEXT_PATH:-$CONTEXT_PATH}"
 echo CATALINA_OPTS: $CATALINA_OPTS
 exec catalina.sh run


### PR DESCRIPTION
The REGISTRY_CONTEXT_PATH env var was not being used; with this change it will use it and if it's not set, it'll use the value of $CONTEXT_PATH.

Also, since you're using bash, I changed the backticks to the currently (mostly) preferred way of command substitution.