### PR TITLE
Exposed 8080 port in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,5 +55,6 @@ RUN ./grailsw test-app unit: -echoOut && \
 
 WORKDIR $CATALINA_BASE
 VOLUME /data
+EXPOSE 8080
 
 CMD ["start.sh"]


### PR DESCRIPTION
Exposed 8080 port in Docker file to allow auto discovery from images like nginx-proxy
