### PR TITLE
feat: upgrade to ubuntu 16.04 and openjdk 8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM    ubuntu:14.04
+FROM    ubuntu:16.04
 
 ENV DEBIAN_FRONTEND noninteractive
 #prevent apt from installing recommended packages
@@ -6,11 +6,11 @@ RUN echo 'APT::Install-Recommends "false";' > /etc/apt/apt.conf.d/docker-no-reco
     echo 'APT::Install-Suggests "false";' >> /etc/apt/apt.conf.d/docker-no-recommends
 
 # Install java and tomcat
-RUN     apt-get update && apt-get install -y tomcat7 openjdk-7-jdk libyaml-perl libfile-slurp-perl && \
+RUN     apt-get update && apt-get install -y tomcat7 openjdk-8-jdk libyaml-perl libfile-slurp-perl && \
         rm -rf /var/lib/tomcat7/webapps/* && \
         rm -rf /var/lib/apt/lists/*
 
-ENV     JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64
+ENV     JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 ENV     CATALINA_HOME /usr/share/tomcat7
 ENV     CATALINA_BASE /var/lib/tomcat7
 


### PR DESCRIPTION
We found out that the tomcat installed on Ubuntu 14.04 doesn't support TLSv1.2 and we need it.

This PR will upgrade the container to Ubuntu 16.04 and use openjdk-8-jdk (7 is not included by default in this Ubuntu version).